### PR TITLE
Remove preset functionality to simplify extension

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -144,26 +144,6 @@
       border: 1px solid #f5c6cb;
     }
     
-    .presets {
-      margin-top: 16px;
-      padding-top: 16px;
-      border-top: 1px solid #e5e5e5;
-    }
-    
-    .preset-button {
-      width: 100%;
-      margin-bottom: 8px;
-      text-align: left;
-      background: #f8f9fa;
-      color: #495057;
-      border: 1px solid #dee2e6;
-      padding: 8px 12px;
-      font-size: 13px;
-    }
-    
-    .preset-button:hover {
-      background: #e9ecef;
-    }
     
     .debug-section {
       margin-top: 8px;
@@ -296,7 +276,6 @@
       <li><strong>Navigate to Tana:</strong> Open <a href="https://app.tana.inc" target="_blank">app.tana.inc</a> in your browser</li>
       <li><strong>Write CSS:</strong> Add your custom CSS in the editor below</li>
       <li><strong>Apply Changes:</strong> Click "Apply CSS" to see your changes</li>
-      <li><strong>Use Presets:</strong> Try the quick presets below for common customizations</li>
     </ol>
     <div class="tips">
       <strong>💡 Tips & Shortcuts:</strong>
@@ -349,13 +328,6 @@
   
   <div id="status" class="status" style="display: none;"></div>
   
-  <div class="presets">
-    <label>Quick Presets</label>
-    <button class="preset-button" data-preset="dark-theme" title="Switch to dark mode with light text on dark backgrounds">🌙 Dark Theme</button>
-    <button class="preset-button" data-preset="larger-text" title="Increase font sizes for better readability">📝 Larger Text</button>
-    <button class="preset-button" data-preset="compact-view" title="Reduce spacing and padding for more content on screen">📦 Compact View</button>
-    <button class="preset-button" data-preset="custom-colors" title="Apply a custom purple color scheme">🎨 Custom Colors</button>
-  </div>
   
   <div class="debug-section">
     <button id="toggle-debug" class="preset-button">Show Debug Info</button>

--- a/popup.js
+++ b/popup.js
@@ -1,96 +1,9 @@
-// Preset CSS configurations
-const PRESETS = {
-  'dark-theme': `
-/* Dark Theme for Tana */
-body, .tana-app {
-  background-color: #1a1a1a !important;
-  color: #e0e0e0 !important;
-}
-
-.tana-sidebar {
-  background-color: #2d2d2d !important;
-  border-right: 1px solid #404040 !important;
-}
-
-.tana-node {
-  background-color: #1a1a1a !important;
-  color: #e0e0e0 !important;
-  border-color: #404040 !important;
-}
-
-.tana-editor {
-  background-color: #1a1a1a !important;
-  color: #e0e0e0 !important;
-}
-
-input, textarea {
-  background-color: #2d2d2d !important;
-  color: #e0e0e0 !important;
-  border-color: #404040 !important;
-}
-`,
-  'larger-text': `
-/* Larger Text for Better Readability */
-.tana-node {
-  font-size: 16px !important;
-  line-height: 1.6 !important;
-}
-
-.tana-sidebar {
-  font-size: 14px !important;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  font-size: 1.2em !important;
-}
-`,
-  'compact-view': `
-/* Compact View for More Content */
-.tana-node {
-  padding: 4px 8px !important;
-  margin: 2px 0 !important;
-  line-height: 1.3 !important;
-}
-
-.tana-sidebar {
-  width: 200px !important;
-  font-size: 12px !important;
-}
-
-.tana-editor {
-  padding: 8px !important;
-}
-`,
-  'custom-colors': `
-/* Custom Color Scheme */
-.tana-node {
-  border-left: 3px solid #667eea !important;
-  background-color: #f8f9ff !important;
-}
-
-.tana-sidebar {
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%) !important;
-}
-
-a, .tana-link {
-  color: #667eea !important;
-}
-
-.tana-tag {
-  background-color: #667eea !important;
-  color: white !important;
-  border-radius: 12px !important;
-  padding: 2px 8px !important;
-}
-`
-};
 
 // DOM elements
 const cssEditor = document.getElementById('css-editor');
 const applyButton = document.getElementById('apply-css');
 const clearButton = document.getElementById('clear-css');
 const statusDiv = document.getElementById('status');
-const presetButtons = document.querySelectorAll('.preset-button');
 const toggleDebugButton = document.getElementById('toggle-debug');
 const debugPanel = document.getElementById('debug-panel');
 const debugContent = document.getElementById('debug-content');
@@ -275,16 +188,6 @@ clearButton.addEventListener('click', async () => {
   }
 });
 
-// Preset button handlers
-presetButtons.forEach(button => {
-  button.addEventListener('click', () => {
-    const presetName = button.dataset.preset;
-    if (PRESETS[presetName]) {
-      cssEditor.value = PRESETS[presetName];
-      showStatus(`${button.textContent} preset loaded`, 'success');
-    }
-  });
-});
 
 // Function to inject CSS into the page
 function injectCustomCSS(css) {


### PR DESCRIPTION
## Summary
- Remove all preset CSS configurations (dark theme, larger text, compact view, custom colors)
- Remove preset buttons and related styling from popup UI
- Remove preset-related instructions from help text
- Clean up unused DOM selectors and event handlers

## Test plan
- [ ] Load extension in Chrome developer mode
- [ ] Verify popup opens without preset section
- [ ] Confirm custom CSS editor still works properly
- [ ] Test Apply CSS and Clear buttons functionality
- [ ] Verify debug panel and instructions toggle still work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed Features**
	- The "Quick Presets" section, including preset buttons for themes and styles, has been removed from the popup interface.
	- Users can no longer apply preset CSS themes directly from the popup.
- **User Interface**
	- The popup layout no longer displays the "Quick Presets" area or related instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->